### PR TITLE
fix compilation cmd for Windows

### DIFF
--- a/dotNet/compile.sh
+++ b/dotNet/compile.sh
@@ -3,10 +3,10 @@
 case "$(uname -s)" in
 
    CYGWIN*|MINGW*|MSYS*)
-     csc src/*.cs -out:server.exe;;
-     
+     csc -out:server.exe -recurse:*.cs;;
+
 
    *)
      mcs src/*.cs -pkg:wcf -out:server.exe;;
-     
+
 esac


### PR DESCRIPTION
- Compilation
Fix the command for Windows.
Tried it with .NET framework 3.5 and 4.8
  
Potential issue: `./compile.sh: line 6: csc: command not found`
Resolution: add Microsoft.NET Framework to your PATH environment variable

- Execution:
I was not able to run the `server.exe` directly from the Windows command prompt, I had to use the one installed with Mono...

```Exception non gérée : System.InvalidOperationException: L'opération « FindPaymentById » du contrat « IPaymentService » a une variable de chemin d'accès nommée « identifier » qui ne contient pas de type « string ». Les variables pour les segments de chemin d'accès UriTemplate doivent avoir un type « string ».                                                                                                                à System.ServiceModel.Dispatcher.UriTemplateClientFormatter.Populate(Dictionary`2& pathMapping, Dictionary`2& queryMapping, Int32& totalNumUTVars, UriTemplate& uriTemplate, OperationDescription operationDescription, QueryStringConverter qsc, String contractName)                                                                                                                                                            à System.ServiceModel.Dispatcher.UriTemplateDispatchFormatter..ctor(OperationDescription operationDescription, IDispatchMessageFormatter inner, QueryStringConverter qsc, String contractName, Uri baseAddress)                                                                                                                                                                                                                   à System.ServiceModel.Description.WebHttpBehavior.GetRequestDispatchFormatter(OperationDescription operationDescription, ServiceEndpoint endpoint)                                                               à System.ServiceModel.Description.WebHttpBehavior.ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)                                                                         à System.ServiceModel.Description.DispatcherBuilder.InitializeServiceHost(ServiceDescription description, ServiceHostBase serviceHost)                                                                           à System.ServiceModel.ServiceHostBase.InitializeRuntime()                                                                                                                                                        à System.ServiceModel.ServiceHostBase.OnOpen(TimeSpan timeout)                                                                                                                                                   à System.ServiceModel.Channels.CommunicationObject.Open(TimeSpan timeout)                                                                                                                                        à Server.start()                                                                                                                                                                                                 à Server.Main(String[] args)```

