### PR TITLE
Forcing distro usage 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ language: java  # Java is the main language for this project
 jdk:            # Running using Oracle JDK 8
   - oraclejdk8
 
+dist: trusty    # fix issues on updated default Ubuntu distro used by Travis
+
 sudo: required  # Mandatory to run docker
 
 services:       # Activating Docker support for this build


### PR DESCRIPTION
as default Ubuntu distro used by Travis has changed and fails jdk8 builds.

Travis CI now builds: https://travis-ci.org/collet/4A_ISA_TheCookieFactory/builds/646360520?utm_medium=notification&utm_source=email

Ref to issue: https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/5